### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/gopalakrishnay/af35480e-77e5-4e47-af27-2da63b19bf1a/4d67064d-bab0-472a-b281-179a4f924972/_apis/work/boardbadge/471cb879-75f4-4126-a906-9e96a38c183c)](https://dev.azure.com/gopalakrishnay/af35480e-77e5-4e47-af27-2da63b19bf1a/_boards/board/t/4d67064d-bab0-472a-b281-179a4f924972/Microsoft.RequirementCategory)
 # GopalWebProject
 
 Test project


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/gopalakrishnay/af35480e-77e5-4e47-af27-2da63b19bf1a/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.